### PR TITLE
Add initial Next.js frontend with dashboard

### DIFF
--- a/app/automation/new/page.tsx
+++ b/app/automation/new/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Form, Input, Select, Switch, Button } from 'antd';
+import { useTranslations } from 'next-intl';
+
+export default function NewAutomationPage() {
+  const t = useTranslations('automation');
+
+  const onFinish = (values: any) => {
+    console.log(values);
+  };
+
+  return (
+    <Form layout="vertical" onFinish={onFinish} style={{ maxWidth: 600 }}>
+      <Form.Item name="trigger" label={t('trigger')} rules={[{ required: true }]}> 
+        <Select options={[{ value: 'close', label: 'After Ticket Closed' }]} />
+      </Form.Item>
+      <Form.Item name="action" label={t('action')} rules={[{ required: true }]}> 
+        <Select options={[{ value: 'email', label: 'Send Email' }]} />
+      </Form.Item>
+      <Form.Item name="conditions" label={t('conditions')}>
+        <Input />
+      </Form.Item>
+      <Form.Item name="status" label={t('status')} valuePropName="checked">
+        <Switch />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">{t('create')}</Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/app/automation/page.tsx
+++ b/app/automation/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Table, Switch, Button } from 'antd';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+interface Rule {
+  key: string;
+  name: string;
+  trigger: string;
+  action: string;
+  active: boolean;
+}
+
+const data: Rule[] = [
+  { key: '1', name: 'Follow up', trigger: 'After Ticket Closed', action: 'Send Email', active: true }
+];
+
+export default function AutomationPage() {
+  const t = useTranslations('automation');
+
+  const columns = [
+    { title: t('ruleName'), dataIndex: 'name', key: 'name' },
+    { title: t('trigger'), dataIndex: 'trigger', key: 'trigger' },
+    { title: t('action'), dataIndex: 'action', key: 'action' },
+    {
+      title: t('status'),
+      dataIndex: 'active',
+      key: 'status',
+      render: (value: boolean) => <Switch checked={value} />
+    }
+  ];
+
+  return (
+    <div>
+      <Link href="/automation/new">
+        <Button type="primary" style={{ marginBottom: 16 }}>{t('createRule')}</Button>
+      </Link>
+      <Table columns={columns} dataSource={data} />
+    </div>
+  );
+}

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Select } from 'antd';
+import { useRouter, usePathname } from 'next-intl/client';
+import { useLocale } from 'next-intl';
+
+export default function LanguageSwitcher() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const locale = useLocale();
+
+  const onChange = (value: string) => {
+    router.push(pathname, { locale: value });
+  };
+
+  return (
+    <Select
+      value={locale}
+      onChange={onChange}
+      options={[
+        { value: 'en', label: 'EN' },
+        { value: 'th', label: 'TH' }
+      ]}
+      style={{ width: 80 }}
+      size="small"
+    />
+  );
+}

--- a/app/customers/[id]/page.tsx
+++ b/app/customers/[id]/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Card, Tabs } from 'antd';
+import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+export default function CustomerDetailPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const t = useTranslations('customers');
+
+  return (
+    <div>
+      <Card title={`${t('profile')}: ${id}`} style={{ marginBottom: 16 }}>
+        <p>Email: example@example.com</p>
+        <p>Phone: 0000000000</p>
+        <p>Total Spend: $1000</p>
+      </Card>
+      <Tabs
+        items={[
+          { key: 'products', label: t('products'), children: <p>Product History</p> },
+          { key: 'cases', label: t('cases'), children: <p>Service Cases</p> },
+          { key: 'activities', label: t('activities'), children: <p>Activity Log</p> }
+        ]}
+      />
+    </div>
+  );
+}

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Table, Input } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import api from '../../utils/api';
+
+interface Customer {
+  key: string;
+  name: string;
+  phone: string;
+  email: string;
+  tags: string[];
+  lastActivity: string;
+}
+
+export default function CustomersPage() {
+  const t = useTranslations('customers');
+  const [search, setSearch] = useState('');
+  const [data, setData] = useState<Customer[]>([]);
+
+  useEffect(() => {
+    api.get('/api/customers').then((res) => setData(res.data));
+  }, []);
+
+  const filtered = data.filter(
+    (c) => c.name.toLowerCase().includes(search.toLowerCase()) || c.phone.includes(search)
+  );
+
+  const columns: ColumnsType<Customer> = [
+    {
+      title: t('name'),
+      dataIndex: 'name',
+      key: 'name'
+    },
+    {
+      title: t('phone'),
+      dataIndex: 'phone',
+      key: 'phone'
+    },
+    {
+      title: t('email'),
+      dataIndex: 'email',
+      key: 'email'
+    },
+    {
+      title: t('tags'),
+      dataIndex: 'tags',
+      key: 'tags',
+      render: (tags) => tags.join(', ')
+    },
+    {
+      title: t('lastActivity'),
+      dataIndex: 'lastActivity',
+      key: 'lastActivity'
+    },
+    {
+      title: t('action'),
+      key: 'action',
+      render: () => <a>{t('view')}</a>
+    }
+  ];
+
+  return (
+    <div>
+      <Input.Search
+        placeholder={t('name')}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        style={{ marginBottom: 16, maxWidth: 300 }}
+      />
+      <Table columns={columns} dataSource={filtered} />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,63 @@
+import { ConfigProvider, Layout, Menu, Avatar, Space } from 'antd';
+import Link from 'next/link';
+import { NextIntlClientProvider, useMessages, useLocale, useTranslations } from 'next-intl';
+import { AntdRegistry } from '@ant-design/nextjs-registry';
+import type { ReactNode } from 'react';
+import themeConfig from '../theme/themeConfig';
+import LanguageSwitcher from './components/LanguageSwitcher';
+import '../globals.css';
+
+const { Header, Sider, Content } = Layout;
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const messages = useMessages();
+  const locale = useLocale();
+  const t = useTranslations('menu');
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <AntdRegistry>
+            <ConfigProvider theme={themeConfig}>
+              <Layout style={{ minHeight: '100vh' }}>
+                <Sider breakpoint="lg" collapsedWidth="0">
+                  <div style={{ color: '#fff', padding: 16, fontWeight: 'bold' }}>CRM</div>
+                  <Menu theme="dark" mode="inline">
+                    <Menu.Item key="dashboard">
+                      <Link href="/">{t('dashboard')}</Link>
+                    </Menu.Item>
+                    <Menu.Item key="customers">
+                      <Link href="/customers">{t('customers')}</Link>
+                    </Menu.Item>
+                    <Menu.Item key="tickets">
+                      <Link href="/tickets">{t('tickets')}</Link>
+                    </Menu.Item>
+                    <Menu.Item key="automation">
+                      <Link href="/automation">{t('automation')}</Link>
+                    </Menu.Item>
+                    <Menu.Item key="leads">
+                      <Link href="/leads">{t('leads')}</Link>
+                    </Menu.Item>
+                  </Menu>
+                </Sider>
+                <Layout>
+                  <Header style={{ background: '#fff', padding: '0 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <div />
+                    <Space>
+                      <LanguageSwitcher />
+                      <Avatar size="small">A</Avatar>
+                    </Space>
+                  </Header>
+                  <Content style={{ margin: 16 }}>
+                    {children}
+                  </Content>
+                </Layout>
+              </Layout>
+            </ConfigProvider>
+          </AntdRegistry>
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/leads/new/page.tsx
+++ b/app/leads/new/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Form, Input, Button, Select } from 'antd';
+import { useTranslations } from 'next-intl';
+
+export default function NewLeadPage() {
+  const t = useTranslations('leads');
+
+  const onFinish = (values: any) => {
+    console.log(values);
+  };
+
+  return (
+    <Form layout="vertical" onFinish={onFinish} style={{ maxWidth: 600 }}>
+      <Form.Item name="name" label={t('name')} rules={[{ required: true }]}> 
+        <Input />
+      </Form.Item>
+      <Form.Item name="contact" label={t('contact')}> 
+        <Input />
+      </Form.Item>
+      <Form.Item name="source" label={t('source')}> 
+        <Select options={[{ value: 'web', label: 'Website' }]} />
+      </Form.Item>
+      <Form.Item name="assignedTo" label={t('assigned')}> 
+        <Select options={[{ value: 'Jane', label: 'Jane' }]} />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">{t('create')}</Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { Card, Col, Row } from 'antd';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+const initial = {
+  new: [{ id: '1', name: 'Acme Corp', value: 5000, rep: 'Jane' }],
+  contacted: [],
+  quoted: [],
+  won: [],
+  lost: []
+};
+
+export default function LeadsPage() {
+  const t = useTranslations('leads');
+  const [columns, setColumns] = useState(initial);
+
+  const onDragEnd = (result: any) => {
+    if (!result.destination) return;
+    const sourceCol = result.source.droppableId as keyof typeof columns;
+    const destCol = result.destination.droppableId as keyof typeof columns;
+    const item = columns[sourceCol][result.source.index];
+    const newSource = Array.from(columns[sourceCol]);
+    newSource.splice(result.source.index, 1);
+    const newDest = Array.from(columns[destCol]);
+    newDest.splice(result.destination.index, 0, item);
+    setColumns({ ...columns, [sourceCol]: newSource, [destCol]: newDest });
+  };
+
+  const columnOrder: (keyof typeof columns)[] = ['new', 'contacted', 'quoted', 'won', 'lost'];
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Row gutter={16}>
+        {columnOrder.map((colKey) => (
+          <Col key={colKey} span={4} style={{ minWidth: 200 }}>
+            <h3>{t(colKey)}</h3>
+            <Droppable droppableId={colKey}>
+              {(provided) => (
+                <div ref={provided.innerRef} {...provided.droppableProps} style={{ minHeight: 100 }}>
+                  {columns[colKey].map((lead, index) => (
+                    <Draggable key={lead.id} draggableId={lead.id} index={index}>
+                      {(dragProvided) => (
+                        <div
+                          ref={dragProvided.innerRef}
+                          {...dragProvided.draggableProps}
+                          {...dragProvided.dragHandleProps}
+                          style={{ marginBottom: 8 }}
+                        >
+                          <Card size="small" title={lead.name}>
+                            <p>{t('value')}: {lead.value}</p>
+                            <p>{t('assigned')}: {lead.rep}</p>
+                          </Card>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </Col>
+        ))}
+      </Row>
+    </DragDropContext>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,24 @@
+import { Card, Col, Row } from 'antd';
+import { UserOutlined, MailOutlined, ThunderboltOutlined, DollarOutlined } from '@ant-design/icons';
+import { useTranslations } from 'next-intl';
+
+export default function DashboardPage() {
+  const t = useTranslations('dashboard');
+
+  return (
+    <Row gutter={[16, 16]}>
+      <Col xs={24} md={12} lg={6}>
+        <Card title={t('totalCustomers')} extra={<UserOutlined />}>123</Card>
+      </Col>
+      <Col xs={24} md={12} lg={6}>
+        <Card title={t('ticketsOpen')} extra={<MailOutlined />}>8</Card>
+      </Col>
+      <Col xs={24} md={12} lg={6}>
+        <Card title={t('campaigns')} extra={<ThunderboltOutlined />}>5</Card>
+      </Col>
+      <Col xs={24} md={12} lg={6}>
+        <Card title={t('topSpenders')} extra={<DollarOutlined />}>Acme Corp</Card>
+      </Col>
+    </Row>
+  );
+}

--- a/app/tickets/new/page.tsx
+++ b/app/tickets/new/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Form, Input, Button, Select, Upload } from 'antd';
+import { useTranslations } from 'next-intl';
+
+export default function NewTicketPage() {
+  const t = useTranslations('tickets');
+
+  const onFinish = (values: any) => {
+    console.log(values);
+  };
+
+  return (
+    <Form layout="vertical" onFinish={onFinish} style={{ maxWidth: 600 }}>
+      <Form.Item name="customer" label={t('customer')} rules={[{ required: true }]}> 
+        <Select options={[{ value: '1', label: 'John Brown' }]} />
+      </Form.Item>
+      <Form.Item name="issue" label={t('issue')} rules={[{ required: true }]}> 
+        <Input />
+      </Form.Item>
+      <Form.Item name="description" label={t('description')}> 
+        <Input.TextArea rows={4} />
+      </Form.Item>
+      <Form.Item name="file" label={t('attachment')} valuePropName="fileList">
+        <Upload beforeUpload={() => false}>
+          <Button>{t('upload')}</Button>
+        </Upload>
+      </Form.Item>
+      <Form.Item name="assignedTo" label={t('assignedTo')}> 
+        <Select options={[{ value: 'Jane', label: 'Jane' }]} />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          {t('create')}
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/app/tickets/page.tsx
+++ b/app/tickets/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Button, Table, Select, DatePicker, Space } from 'antd';
+import { useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+interface Ticket {
+  key: string;
+  caseId: string;
+  customer: string;
+  status: string;
+  issue: string;
+  assignedTo: string;
+  createdAt: string;
+}
+
+const data: Ticket[] = [
+  {
+    key: '1',
+    caseId: 'C001',
+    customer: 'John Brown',
+    status: 'Open',
+    issue: 'Login issue',
+    assignedTo: 'Jane',
+    createdAt: '2024-05-01'
+  }
+];
+
+export default function TicketsPage() {
+  const t = useTranslations('tickets');
+  const [status, setStatus] = useState<string>();
+
+  const columns = [
+    { title: t('caseId'), dataIndex: 'caseId', key: 'caseId' },
+    { title: t('customer'), dataIndex: 'customer', key: 'customer' },
+    { title: t('status'), dataIndex: 'status', key: 'status' },
+    { title: t('issue'), dataIndex: 'issue', key: 'issue' },
+    { title: t('assignedTo'), dataIndex: 'assignedTo', key: 'assignedTo' },
+    { title: t('createdAt'), dataIndex: 'createdAt', key: 'createdAt' }
+  ];
+
+  return (
+    <div>
+      <Space style={{ marginBottom: 16 }}>
+        <Select
+          placeholder={t('status')}
+          allowClear
+          value={status}
+          onChange={(v) => setStatus(v)}
+          options={[
+            { value: 'Open', label: 'Open' },
+            { value: 'Closed', label: 'Closed' }
+          ]}
+        />
+        <DatePicker placeholder={t('date')} />
+        <Link href="/tickets/new">
+          <Button type="primary">{t('newTicket')}</Button>
+        </Link>
+      </Space>
+      <Table columns={columns} dataSource={data} />
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,10 @@
+import createMiddleware from 'next-intl/middleware';
+
+export default createMiddleware({
+  locales: ['en', 'th'],
+  defaultLocale: 'en'
+});
+
+export const config = {
+  matcher: ['/((?!api|_next|.*\..*).*)']
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  },
+  i18n: {
+    locales: ['en', 'th'],
+    defaultLocale: 'en'
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "crm-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "antd": "^5.13.3",
+    "@ant-design/icons": "^5.1.0",
+    "next-intl": "^3.3.0",
+    "zustand": "^4.4.1",
+    "axios": "^1.6.2",
+    "react-beautiful-dnd": "^13.1.1"
+  }
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,71 @@
+{
+  "dashboard": {
+    "totalCustomers": "Total Customers",
+    "ticketsOpen": "Tickets Open",
+    "campaigns": "Campaigns",
+    "topSpenders": "Top Spenders"
+  },
+  "customers": {
+    "title": "Customers",
+    "name": "Name",
+    "phone": "Phone",
+    "email": "Email",
+    "tags": "Tags",
+    "lastActivity": "Last Activity",
+    "action": "Action",
+    "view": "View",
+    "profile": "Customer Profile",
+    "products": "Product History",
+    "cases": "Service Cases",
+    "activities": "Activity Log"
+  },
+  "menu": {
+    "dashboard": "Dashboard",
+    "customers": "Customers",
+    "tickets": "Tickets",
+    "automation": "Automation",
+    "leads": "Leads"
+  },
+  "tickets": {
+    "caseId": "Case ID",
+    "customer": "Customer",
+    "status": "Status",
+    "issue": "Issue",
+    "assignedTo": "Assigned To",
+    "createdAt": "Created At",
+    "date": "Date",
+    "newTicket": "New Ticket",
+    "description": "Description",
+    "attachment": "Attachment",
+    "upload": "Upload File",
+    "create": "Create",
+    "cancel": "Cancel"
+  },
+  "automation": {
+    "ruleName": "Rule Name",
+    "trigger": "Trigger",
+    "action": "Action",
+    "status": "Status",
+    "conditions": "Conditions",
+    "createRule": "Create New Rule",
+    "create": "Create"
+  },
+  "leads": {
+    "new": "New",
+    "contacted": "Contacted",
+    "quoted": "Quoted",
+    "won": "Won",
+    "lost": "Lost",
+    "value": "Value",
+    "assigned": "Assigned",
+    "name": "Name",
+    "contact": "Contact",
+    "source": "Source",
+    "create": "Create",
+    "cancel": "Cancel"
+  },
+  "language": {
+    "en": "English",
+    "th": "Thai"
+  }
+}

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -1,0 +1,71 @@
+{
+  "dashboard": {
+    "totalCustomers": "ลูกค้าทั้งหมด",
+    "ticketsOpen": "ตั๋วที่เปิดอยู่",
+    "campaigns": "แคมเปญ",
+    "topSpenders": "ลูกค้าที่ใช้จ่ายสูง"
+  },
+  "customers": {
+    "title": "ลูกค้า",
+    "name": "ชื่อ",
+    "phone": "โทรศัพท์",
+    "email": "อีเมล",
+    "tags": "แท็ก",
+    "lastActivity": "กิจกรรมล่าสุด",
+    "action": "การกระทำ",
+    "view": "ดู",
+    "profile": "ข้อมูลลูกค้า",
+    "products": "ประวัติสินค้า",
+    "cases": "เคสบริการ",
+    "activities": "บันทึกกิจกรรม"
+  },
+  "menu": {
+    "dashboard": "แดชบอร์ด",
+    "customers": "ลูกค้า",
+    "tickets": "ทิกเก็ต",
+    "automation": "ระบบอัตโนมัติ",
+    "leads": "ลีด"
+  },
+  "tickets": {
+    "caseId": "รหัสเคส",
+    "customer": "ลูกค้า",
+    "status": "สถานะ",
+    "issue": "ปัญหา",
+    "assignedTo": "ผู้รับผิดชอบ",
+    "createdAt": "สร้างเมื่อ",
+    "date": "วันที่",
+    "newTicket": "สร้างทิกเก็ต",
+    "description": "รายละเอียด",
+    "attachment": "ไฟล์แนบ",
+    "upload": "อัปโหลดไฟล์",
+    "create": "สร้าง",
+    "cancel": "ยกเลิก"
+  },
+  "automation": {
+    "ruleName": "ชื่อกฎ",
+    "trigger": "ทริกเกอร์",
+    "action": "การกระทำ",
+    "status": "สถานะ",
+    "conditions": "เงื่อนไข",
+    "createRule": "สร้างกฎใหม่",
+    "create": "สร้าง"
+  },
+  "leads": {
+    "new": "ใหม่",
+    "contacted": "ติดต่อแล้ว",
+    "quoted": "เสนอราคา",
+    "won": "ชนะ",
+    "lost": "แพ้",
+    "value": "มูลค่า",
+    "assigned": "ผู้รับผิดชอบ",
+    "name": "ชื่อ",
+    "contact": "การติดต่อ",
+    "source": "แหล่งที่มา",
+    "create": "สร้าง",
+    "cancel": "ยกเลิก"
+  },
+  "language": {
+    "en": "อังกฤษ",
+    "th": "ไทย"
+  }
+}

--- a/store/useAuth.ts
+++ b/store/useAuth.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  user?: { name: string; bu: string };
+  setUser: (user: { name: string; bu: string }) => void;
+  logout: () => void;
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  user: undefined,
+  setUser: (user) => set({ user }),
+  logout: () => set({ user: undefined })
+}));

--- a/theme/themeConfig.ts
+++ b/theme/themeConfig.ts
@@ -1,0 +1,9 @@
+import type { ThemeConfig } from 'antd';
+
+const themeConfig: ThemeConfig = {
+  token: {
+    colorPrimary: '#E1DD00'
+  }
+};
+
+export default themeConfig;

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'https://api.example.com',
+  withCredentials: true
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- initialize Next.js project with Ant Design theme and next-intl
- configure i18n and middleware
- add Zustand auth store and Axios API helper
- scaffold layout with sidebar, topbar and language switcher
- implement dashboard and customers pages with i18n
- add CRM sections: customer details, tickets, automation, and leads
- extend translations for all sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e0bddf58832cb139f3065c2325c6